### PR TITLE
Fix overlapping menu bar

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -4,23 +4,16 @@ import { RouterLink, RouterView } from 'vue-router'
 
 <template>
   <Sidebar /> <!-- Add Sidebar To Page -->
-  <div :style="{'margin-left' : sidebarWidth }"></div>
-  <header>
-    <img @click="clickLogo" alt="Vue logo" class="logo" src="@/assets/scalable-logo.svg"/>
-    <div class="wrapper">
-      <nav>
-        <RouterLink v-if="username" to="/" class="nav-link">Home</RouterLink>
-        <RouterLink v-if="!username" to="/signIn" class="nav-link">Sign in</RouterLink>
-        <RouterLink v-if="username" to="/tripManager" class="nav-link">Manage Trips</RouterLink>
-        <button v-if="username" type="button" class="btn btn-secondary btn-sm" @click="signUserOut" style="margin-left: auto;">Sign Out {{ username }}</button>
-      </nav>
+  <div :style="{'margin-left' : sidebarWidth }">
+    <header>
+      <img @click="clickLogo" alt="Vue logo" class="logo" src="@/assets/scalable-logo.svg"/>
+    </header>
+    <div v-if="alertStatus" class="alert alert-dismissible fade show" :class="alertStatus" role="alert">
+      {{ alertMessage }}
+      <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close" @click="dismissAlert"></button>
     </div>
-  </header>
-  <div v-if="alertStatus" class="alert alert-dismissible fade show" :class="alertStatus" role="alert">
-    {{ alertMessage }}
-    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close" @click="dismissAlert"></button>
+    <RouterView />
   </div>
-<RouterView />
 </template>
 
 <script>
@@ -31,9 +24,6 @@ import { sidebarWidth } from '@/components/state' //Import sidebarWidth
 
 export default {
   components: {Sidebar}, //Retrieve Sidebar Component and return sidebarWidth
-  setup(){
-    return {sidebarWidth}
-  },
   data () {
     return {
       alertStatus: null,

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -4,12 +4,23 @@
 <script>
 import {collapsed, toggleSidebar, sidebarWidth} from './state'
 import SidebarLink from './SidebarLink.vue'
+import { signCurrentUserOut } from '@/api/userVerification'
+
 export default{
     props: {},
     components: {SidebarLink}, // Getting SidebarLink Component
     setup() {
         return {collapsed,toggleSidebar,sidebarWidth} // Returning status of collapsed, toggleSidebar value, and sidebarWidth value
-
+    },
+    computed: {
+      username() {
+        return this.$store.getters.getUsername;
+      }
+    },
+    methods: {
+      signUserOut() {
+        signCurrentUserOut();
+      }
     }
 }</script>
 
@@ -20,20 +31,20 @@ export default{
             <span v-if="collapsed">
             <div class="wrapper">TC</div>
             </span>
-            <span v-else><div class="wrapper">Travel Companion</div></span> 
+            <span v-else><div class="wrapper">Travel Companion</div></span>
         </h2>
         <h5>
         <!-- Sidebar Links -->
-        <SidebarLink to="/" icon="fas fa-home">Home</SidebarLink>
-        <SidebarLink to="/signIn" icon="fas fa-right-to-bracket">Sign In</SidebarLink>
-        <SidebarLink to="/tripManager" icon="fas fa-plane">Trip Manager</SidebarLink>
+        <SidebarLink v-if="username" to="/" icon="fas fa-home">Home</SidebarLink>
+        <SidebarLink v-if="!username" to="/signIn" icon="fas fa-right-to-bracket">Sign In</SidebarLink>
+        <SidebarLink v-if="username" to="/tripManager" icon="fas fa-plane">Trip Manager</SidebarLink>
+        <SidebarLink v-if="username" icon="fas fa-sign-out" @click="signUserOut">Sign Out</SidebarLink>
         <!-- Only displaying icon when sidebar collapsed -->
         </h5>
         <span
             class="collapse-icon"
              :class="{'rotate-180' : collapsed}"
-            @click="toggleSidebar"
-        >
+            @click="toggleSidebar">
         <i class="fas fa-angle-double-left" />
         </span>
     </div>
@@ -80,5 +91,10 @@ export default{
 .rotate-180{
     transform: rotate(180deg);
     transition: 0.2s linear;
+}
+.sign-out {
+    position: absolute;
+    bottom: 0;
+    padding: 0.75em;
 }
 </style>

--- a/src/components/SidebarLink.vue
+++ b/src/components/SidebarLink.vue
@@ -7,7 +7,7 @@ import { collapsed } from './state';
 
 export default {
     props: {
-        to: {type: String, required: true},
+        to: {type: String, required: false},
         icon: { type: String, required: true}
     },
     setup(props){
@@ -20,7 +20,7 @@ export default {
 </script>
 
 <template>
-    <router-link :to="to" class="link" :class="{active: isActive}">
+    <router-link :to="to ? to : '/signIn'" class="link" :class="{active: isActive}">
         <i class="icon" :class="icon" />
         <transition name="fade">
         <span v-if="!collapsed">

--- a/src/components/state.js
+++ b/src/components/state.js
@@ -1,7 +1,7 @@
 import { ref, computed} from 'vue'
 
 //Handling sidebarWidth based on state of collapsed
-export const collapsed = ref(false)
+export const collapsed = ref(true)
 export const toggleSidebar = () => (collapsed.value = !collapsed.value)
 
 export const SIDEBAR_WIDTH = 250


### PR DESCRIPTION
- Closes Issue: https://github.com/WSU-4110/Travel-Companion/issues/30
- Added resizable margin to the main window to allow space for the sidebar
- Removed old menu bar links that were replaced by the sidebar